### PR TITLE
add metrics to service

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
       serviceAccountName: {{ include "cf-service-operator.fullname" . }}
       automountServiceAccountToken: true
       containers:
-      - name: controller
+      - name: cf-service-operator
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
       serviceAccountName: {{ include "cf-service-operator.fullname" . }}
       automountServiceAccountToken: true
       containers:
-      - name: cf-service-operator
+      - name: {{ include "cf-service-operator.name" . }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       protocol: TCP
       targetPort: webhooks
       name: https
+    - name: metrics
+      port: 8080
+      protocol: TCP
+      targetPort: metrics
   selector:
     {{- include "cf-service-operator.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
For prometheus scraping via service-monitor let's extend the service with a well known metrics path.
Furthermore let's have a specific name for the container, for easier detection within Grafana Dashboards (we may discuss also dynamic naming of the container via values.yaml).